### PR TITLE
fix package.json to reference the actual JS file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "leaflet.projwmts",
   "version": "1.0.0",
   "description": "Leaflet wmts layer with projection",
-  "main": "src/TileLayer.ProjWMS.js",
+  "main": "src/TileLayer.ProjWMTS.js",
   "scripts": {
     "serve": "live-server --port=8084"
   },


### PR DESCRIPTION
otherwise webpack (and most likely any other build tool) is not able to properly resolve source file