### PR TITLE
Poprawa nazwy pliku w package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "leaflet.projwmts",
   "version": "1.0.0",
   "description": "Leaflet wmts layer with projection",
-  "main": "src/TileLayer.ProjWMS.js",
+  "main": "src/TileLayer.ProjWMTS.js",
   "scripts": {
     "serve": "live-server --port=8084"
   },


### PR DESCRIPTION
Podana nazwa jest błędna co powoduje, że NodeJS nie jest wstanie poprawnie zaimportować tej biblioteki.
Ta mała poprawka powinna załatwić sprawę.